### PR TITLE
Turnout with numeric

### DIFF
--- a/R/cps_label.R
+++ b/R/cps_label.R
@@ -25,7 +25,7 @@ cps_label <- function(data,
                       na_vals = c("-1", "BLANK", "NOT IN UNIVERSE"),
                       expand_year = TRUE,
                       rescale_weight = TRUE) {
-  YEAR <- YEAR4 <- year <- index <- WEIGHT <- NULL
+  cps_turnout <- achenhur_turnout <- YEAR <- YEAR4 <- year <- index <- WEIGHT <- NULL
   
   data <- data %>%
     dplyr::mutate(index = dplyr::row_number(),
@@ -73,17 +73,17 @@ cps_label <- function(data,
   
   # bonus columns in case this happens after the vote reweighting
   if("turnout_weight" %in% colnames(output)) {
-    output <- mutate(output, turnout_weight = dplyr::case_when(is.na(turnout_weight) ~ 0,
+    output <- dplyr::mutate(output, turnout_weight = dplyr::case_when(is.na(turnout_weight) ~ 0,
                                                        rescale_weight ~ turnout_weight / 10000, 
                                                        TRUE ~ as.double(turnout_weight)))
   }
   if("cps_turnout" %in% colnames(output)) {
-    output <- mutate(output, cps_turnout = factor(cps_turnout,
+    output <- dplyr::mutate(output, cps_turnout = factor(cps_turnout,
                                                   levels = 1:2,
                                                   labels = c("YES", "NO")))
   }
   if("achenhur_turnout" %in% colnames(output)) {
-    output <- mutate(output, achenhur_turnout = factor(achenhur_turnout,
+    output <- dplyr::mutate(output, achenhur_turnout = factor(achenhur_turnout,
                                                   levels = 1:2,
                                                   labels = c("YES", "NO")))
   }

--- a/R/cps_label.R
+++ b/R/cps_label.R
@@ -71,6 +71,22 @@ cps_label <- function(data,
                                             rescale_weight ~ WEIGHT / 10000, 
                                             TRUE ~ as.double(WEIGHT))) # fix the 4-decimal weight if asked
   
+  # bonus columns in case this happens after the vote reweighting
+  if("turnout_weight" %in% colnames(output)) {
+    output <- mutate(output, turnout_weight = dplyr::case_when(is.na(turnout_weight) ~ 0,
+                                                       rescale_weight ~ turnout_weight / 10000, 
+                                                       TRUE ~ as.double(turnout_weight)))
+  }
+  if("cps_turnout" %in% colnames(output)) {
+    output <- mutate(output, cps_turnout = factor(cps_turnout,
+                                                  levels = 1:2,
+                                                  labels = c("YES", "NO")))
+  }
+  if("achenhur_turnout" %in% colnames(output)) {
+    output <- mutate(output, achenhur_turnout = factor(achenhur_turnout,
+                                                  levels = 1:2,
+                                                  labels = c("YES", "NO")))
+  }
   
   return(output)
 }

--- a/R/cps_reweight_turnout.R
+++ b/R/cps_reweight_turnout.R
@@ -17,7 +17,7 @@ cps_reweight_turnout <- function(data) {
     reweight <- reweight %>%
       dplyr::rowwise() %>%
       dplyr::mutate(response = as.numeric(response),
-                    STATE = unique(cps_factors$code[cps_factors$value == STATE]),
+                    STATE = unique(cpsvote::cps_factors$code[cpsvote::cps_factors$value == STATE]),
                     YEAR = dplyr::case_when(YEAR < 1998 ~ as.integer(YEAR %% 1900),
                                      TRUE ~ YEAR))
   }

--- a/R/cps_reweight_turnout.R
+++ b/R/cps_reweight_turnout.R
@@ -12,6 +12,16 @@ cps_reweight_turnout <- function(data) {
   reweight <- cpsvote::cps_reweight %>%
     dplyr::select(YEAR, STATE, response, reweight) %>%
     dplyr::mutate(YEAR = as.integer(YEAR))
+  
+  if(is.numeric(data$achenhur_turnout)) {
+    reweight <- reweight %>%
+      dplyr::rowwise() %>%
+      dplyr::mutate(response = as.numeric(response),
+                    STATE = unique(cps_factors$code[cps_factors$value == STATE]),
+                    YEAR = dplyr::case_when(YEAR < 1998 ~ as.integer(YEAR %% 1900),
+                                     TRUE ~ YEAR))
+  }
+  
   output <- data %>%
     dplyr::left_join(reweight, by = c("YEAR", "STATE", "achenhur_turnout" = "response")) %>%
     dplyr::mutate(reweight = dplyr::coalesce(reweight, 1), # if it's missing, just return the original

--- a/R/refactor.R
+++ b/R/refactor.R
@@ -134,11 +134,11 @@ cps_recode_vote <- function(data,
                             items = c("DON'T KNOW", "REFUSED", "NO RESPONSE")) {
   if (is.numeric(data[[vote_col]])) {
     output <- dplyr::mutate(data,
-                            cps_turnout = case_when(
+                            cps_turnout = dplyr::case_when(
                               .data[[vote_col]] %in% c(1) ~ 1,
                               .data[[vote_col]] %in% c(2, -2, -3, -9) ~ 2
                             ),
-                            achenhur_turnout = case_when(
+                            achenhur_turnout = dplyr::case_when(
                               .data[[vote_col]] %in% c(1) ~ 1,
                               .data[[vote_col]] %in% c(2) ~ 2
                             ))

--- a/R/refactor.R
+++ b/R/refactor.R
@@ -132,16 +132,28 @@ cps_refactor <- function(data, move_levels = TRUE) {
 cps_recode_vote <- function(data, 
                             vote_col = "VRS_VOTE",
                             items = c("DON'T KNOW", "REFUSED", "NO RESPONSE")) {
-  output <- suppressWarnings( # this is a dumb suppress but I really can't figure out why `fct_other` is throwing it
-    dplyr::mutate(data,
-                  cps_turnout = forcats::fct_collapse(.data[[vote_col]], "NO" = items) %>% # recode the items as NO
-                    forcats::fct_other(keep = c("YES", "NO")) %>% # send everything that's not Y/N to "Other"
-                    forcats::fct_expand("Other") %>% # if there are no Others, add the level (to avoid warning in  next step)
-                    forcats::fct_collapse(NULL = "Other"), # drop all Other
-                  achenhur_turnout = forcats::fct_other(.data[[vote_col]], keep = c("YES", "NO")) %>% # send everything that's not Y/N to "Other"
-                    forcats::fct_expand("Other") %>% # if there are no Others, add the level (to avoid warning in  next step)
-                    forcats::fct_collapse(NULL = "Other") # drop all Other
-    ))
+  if (is.numeric(data[[vote_col]])) {
+    output <- dplyr::mutate(data,
+                            cps_turnout = case_when(
+                              .data[[vote_col]] %in% c(1) ~ 1,
+                              .data[[vote_col]] %in% c(2, -2, -3, -9) ~ 2
+                            ),
+                            achenhur_turnout = case_when(
+                              .data[[vote_col]] %in% c(1) ~ 1,
+                              .data[[vote_col]] %in% c(2) ~ 2
+                            ))
+  } else {
+    output <- suppressWarnings( # this is a dumb suppress but I really can't figure out why `fct_other` is throwing it
+      dplyr::mutate(data,
+                    cps_turnout = forcats::fct_collapse(.data[[vote_col]], "NO" = items) %>% # recode the items as NO
+                      forcats::fct_other(keep = c("YES", "NO")) %>% # send everything that's not Y/N to "Other"
+                      forcats::fct_expand("Other") %>% # if there are no Others, add the level (to avoid warning in  next step)
+                      forcats::fct_collapse(NULL = "Other"), # drop all Other
+                    achenhur_turnout = forcats::fct_other(.data[[vote_col]], keep = c("YES", "NO")) %>% # send everything that's not Y/N to "Other"
+                      forcats::fct_expand("Other") %>% # if there are no Others, add the level (to avoid warning in  next step)
+                      forcats::fct_collapse(NULL = "Other") # drop all Other
+      ))
+  }
   
   output
 }


### PR DESCRIPTION
Addresses #14, by adding options for the vote reweight/recode functions when the original vote column is still numeric. You can now do vote reweighting BEFORE attaching labels to the data.